### PR TITLE
fix: restore spec & remove ci on tags

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,6 +1,11 @@
 name: Node.js Build
 
-on: push
+on: 
+  push: true
+
+  # release-it specs fail when running on tags.
+  tags-ignore:
+  - '**'
 
 jobs:
   build:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,11 +1,13 @@
 name: Node.js Build
 
-on: 
-  push: true
+on:
+  push:
+    branches:
+      - '**'
 
-  # release-it specs fail when running on tags.
-  tags-ignore:
-  - '**'
+    # release-it specs fail when running on tags.
+    tags-ignore:
+    - '**'
 
 jobs:
   build:

--- a/test/release-it.js
+++ b/test/release-it.js
@@ -1,19 +1,21 @@
-// const { expect } = require('@dimensionalpocket/development')
-// const release = require('release-it')
-// const defaults = require('../')
+// This spec fails on GitHub Actions when running on tags.
 
-// describe('release-it', function () {
-//   it('works with default options (except only-version)', async function () {
-//     var testOptions = {
-//       'only-version': false,
-//       'dry-run': true,
-//       ci: true // skip all prompts
-//     }
+const { expect } = require('@dimensionalpocket/development')
+const release = require('release-it')
+const defaults = require('../')
 
-//     var options = Object.assign(testOptions, defaults)
-//     options.git.requireCleanWorkingDir = false // will be dirty during tests
+describe('release-it', function () {
+  it('works with default options (except only-version)', async function () {
+    var testOptions = {
+      'only-version': false,
+      'dry-run': true,
+      ci: true // skip all prompts
+    }
 
-//     var output = await release(options)
-//     expect(output.version).to.exist
-//   })
-// })
+    var options = Object.assign(testOptions, defaults)
+    options.git.requireCleanWorkingDir = false // will be dirty during tests
+
+    var output = await release(options)
+    expect(output.version).to.exist
+  })
+})


### PR DESCRIPTION
Spec is broken when running GH actions on tag creation so skip tags from CI.